### PR TITLE
Do not instruct users to publish assets from other packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Then add the facade to your `aliases` array:
 ],
 ```
 
-Finally, publish the config file with `php artisan config:publish maknz/slack`. You'll find the config file at `app/config/packages/maknz/slack-laravel/config.php`.
+Finally, publish the config file with `php artisan config:publish maknz/slack --provider="Maknz\Slack\Laravel\ServiceProvider"`. You'll find the config file at `app/config/packages/maknz/slack-laravel/config.php`.
 
 ## Configuration
 


### PR DESCRIPTION
This PR changes the readme so it instructs users to only publish assets by this package.
More info: https://murze.be/2016/04/publishing-package-assets-right-way/