### PR TITLE
Update compatibility to latest Laravel 5.4

### DIFF
--- a/src/ServiceProviderLaravel5.php
+++ b/src/ServiceProviderLaravel5.php
@@ -26,7 +26,7 @@ class ServiceProviderLaravel5 extends \Illuminate\Support\ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/config/config.php', 'slack');
 
-        $this->app['maknz.slack'] = $this->app->share(function ($app) {
+        $this->app['maknz.slack'] = $this->app->singleton(function ($app) {
             return new Client(
                 $app['config']->get('slack.endpoint'),
                 [


### PR DESCRIPTION
As in docs: https://laravel.com/docs/5.4/upgrade

share Method Removed

The share method has been removed from the container. This was a legacy method that has not been documented in several years. If you are using this method, you should begin using the singleton method instead.