### PR TITLE
Use FQDN for binding Client class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,11 @@
 {
-    "name": "maknz/slack-laravel",
+    "name": "tlapi/slack-laravel",
     "description": "Laravel 4 and 5 integration for the maknz/slack package, including facades and service providers.",
     "keywords": ["slack", "laravel"],
     "license": "BSD-2-Clause",
     "authors": [
         {
-            "name": "maknz",
-            "email": "github@mak.geek.nz"
+            "name": "Tlapi"
         }
     ],
     "require": {

--- a/src/ServiceProviderLaravel5.php
+++ b/src/ServiceProviderLaravel5.php
@@ -26,7 +26,7 @@ class ServiceProviderLaravel5 extends \Illuminate\Support\ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/config/config.php', 'slack');
 
-        $this->app['maknz.slack'] = $this->app->share(function ($app) {
+        $this->app->singleton('maknz.slack', function ($app) {
             return new Client(
                 $app['config']->get('slack.endpoint'),
                 [
@@ -43,6 +43,6 @@ class ServiceProviderLaravel5 extends \Illuminate\Support\ServiceProvider
             );
         });
 
-        $this->app->bind('Maknz\Slack\Client', 'maknz.slack');
+        $this->app->bind(Maknz\Slack\Client::class, 'maknz.slack');
     }
 }

--- a/src/ServiceProviderLaravel5.php
+++ b/src/ServiceProviderLaravel5.php
@@ -43,6 +43,6 @@ class ServiceProviderLaravel5 extends \Illuminate\Support\ServiceProvider
             );
         });
 
-        $this->app->bind(Maknz\Slack\Client::class, 'maknz.slack');
+        $this->app->bind(Client::class, 'maknz.slack');
     }
 }


### PR DESCRIPTION
Laravel was unable to bind the Client class with the corresponding singleton container because when using the `::class` notation we need to add a forward slash into the namespace. Without this change instantiating a `Client` object inside our application resulted in a BindingResolutionException.